### PR TITLE
fix: test all phone formats

### DIFF
--- a/out/phone_parser.js
+++ b/out/phone_parser.js
@@ -156,6 +156,6 @@ function validateAndAddCodeIfNeeded(phone, PhoneFormats) {
         else if (phone.length === code.length - code.code.length) {
             return code + phone;
         }
-        return undefined;
     }
+    return undefined;
 }

--- a/src/phone_parser.ts
+++ b/src/phone_parser.ts
@@ -126,7 +126,7 @@ function validateAndAddCodeIfNeeded(phone: string, PhoneFormats: PhoneFormat[]):
     else if(phone.length === code.length - code.code.length){
       return code + phone;
     }
-    return undefined;
   }
-}
 
+  return undefined;
+}


### PR DESCRIPTION
Old code returned from the loop early, so it was checking only one phone format, and if check failed, it returned `undefined`. Instead, it should check _every_ phone format and return `undefined` only if _all_ checks failed